### PR TITLE
Provide a default for the 'opts' argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var polymerCssBuild = require('polymer-css-build').polymerCssBuild;
 /**
  * @param {Config} [opts] the configuration
  */
-module.exports = function (opts) {
+module.exports = function (opts = {}) {
   const inputDocs = [];
 
   const stream = through.obj(function (file, enc, cb) {


### PR DESCRIPTION
The `opts` argument is marked as optional in the JSDoc comment, and the upstream polymer-css-build doesn't specifically mark it as optional. So, provide a default value.

Incidentally: This fixes the test failures for #3. :)

I also filed an upstream issue: options used to be factually optional, but a change in 0.1.0 made this no longer true. See https://github.com/Polymer/polymer-css-build/issues/11 for that one.